### PR TITLE
Don't use IV_Melee as a tiebreaker in RelevantInstancesForTraits.

### DIFF
--- a/PalCalc.Solver/BreedingSolver.cs
+++ b/PalCalc.Solver/BreedingSolver.cs
@@ -121,7 +121,7 @@ namespace PalCalc.Solver
                             .Select(instances => instances
                                 .OrderBy(i => i.Traits.Count)
                                 .ThenBy(i => PreferredLocationPruning.LocationOrderingOf(i.Location.Type))
-                                .ThenByDescending(i => i.IV_HP + i.IV_Melee + i.IV_Shot + i.IV_Defense)
+                                .ThenByDescending(i => i.IV_HP + i.IV_Shot + i.IV_Defense)
                                 .First()
                             )
                     );


### PR DESCRIPTION
This stat is unused and skews the results.