### PR TITLE
Add an option to change which pals can be bred.

### DIFF
--- a/PalCalc.Solver.CLI/Program.cs
+++ b/PalCalc.Solver.CLI/Program.cs
@@ -31,6 +31,7 @@ internal class Program
             maxBreedingSteps: 20,
             maxWildPals: 1,
             allowedWildPals: db.Pals.ToList(),
+            bannedBredPals: new List<Pal>(),
             maxBredIrrelevantTraits: 0,
             maxInputIrrelevantTraits: 2,
             maxEffort: TimeSpan.FromDays(7),

--- a/PalCalc.Solver/BreedingSolver.cs
+++ b/PalCalc.Solver/BreedingSolver.cs
@@ -41,6 +41,7 @@ namespace PalCalc.Solver
         List<PalInstance> ownedPals;
 
         List<Pal> allowedWildPals;
+        List<Pal> bannedBredPals;
         int maxBreedingSteps, maxWildPals, maxBredIrrelevantTraits, maxInputIrrelevantTraits;
         TimeSpan maxEffort;
         PruningRulesBuilder pruningBuilder;
@@ -66,6 +67,7 @@ namespace PalCalc.Solver
             int maxBreedingSteps,
             int maxWildPals,
             List<Pal> allowedWildPals,
+            List<Pal> bannedBredPals,
             int maxInputIrrelevantTraits,
             int maxBredIrrelevantTraits,
             TimeSpan maxEffort,
@@ -78,6 +80,7 @@ namespace PalCalc.Solver
             this.ownedPals = ownedPals;
             this.maxBreedingSteps = maxBreedingSteps;
             this.allowedWildPals = allowedWildPals;
+            this.bannedBredPals = bannedBredPals;
             this.maxWildPals = maxWildPals;
             this.maxInputIrrelevantTraits = Math.Min(3, maxInputIrrelevantTraits);
             this.maxBredIrrelevantTraits = Math.Min(3, maxBredIrrelevantTraits);
@@ -616,8 +619,11 @@ namespace PalCalc.Solver
                                                 probabilityForUpToNumTraits
                                             );
 
-                                            if (res.BreedingEffort <= maxEffort && (spec.IsSatisfiedBy(res) || workingSet.IsOptimal(res)))
-                                                possibleResults.Add(res);
+                                            if (!bannedBredPals.Contains(res.Pal))
+                                            {
+                                                if (res.BreedingEffort <= maxEffort && (spec.IsSatisfiedBy(res) || workingSet.IsOptimal(res)))
+                                                    possibleResults.Add(res);
+                                            }
                                         }
                                     }
 

--- a/PalCalc.UI/Model/AppSettings.cs
+++ b/PalCalc.UI/Model/AppSettings.cs
@@ -16,11 +16,13 @@ namespace PalCalc.UI.Model
         public int MaxBredIrrelevantTraits { get; set; } = 1;
         public int MaxThreads { get; set; } = 0;
 
+        public List<string> BannedBredPalInternalNames { get; set; } = [];
         public List<string> BannedWildPalInternalNames { get; set; } = [
             "HerculesBeetle_Ground", // warsect terra, not released yet
             "PlantSlime_Flower", // flower gumoss
         ];
 
+        public List<Pal> BannedBredPals(PalDB db) => BannedBredPalInternalNames.Select(n => n.InternalToPal(db)).ToList();
         public List<Pal> BannedWildPals(PalDB db) => BannedWildPalInternalNames.Select(n => n.InternalToPal(db)).ToList();
     }
 

--- a/PalCalc.UI/View/SolverControlsView.xaml
+++ b/PalCalc.UI/View/SolverControlsView.xaml
@@ -21,15 +21,18 @@
         </Style>
     </WrapPanel.Resources>
 
-    <StackPanel Orientation="Horizontal" Margin="10,0" VerticalAlignment="Center">
-        <Label Content="Max Breeding Steps" />
-        <v:IntegerTextBox
-                Value="{Binding MaxBreedingSteps}"
-                IsEnabled="{Binding CanEditSettings}"
-                MinValue="1" MaxValue="99"
-                ToolTipService.ToolTip="The maximum number of solver iterations, and the max number of breeding steps to reach the target pal.&#10;Higher values linearly affect time required."
-                ToolTipService.ShowOnDisabled="True"
+    <StackPanel Margin="10,0" VerticalAlignment="Center">
+        <StackPanel Orientation="Horizontal" Margin="0,0,0,3">
+            <Label Content="Max Breeding Steps" />
+            <v:IntegerTextBox
+                    Value="{Binding MaxBreedingSteps}"
+                    IsEnabled="{Binding CanEditSettings}"
+                    MinValue="1" MaxValue="99"
+                    ToolTipService.ToolTip="The maximum number of solver iterations, and the max number of breeding steps to reach the target pal.&#10;Higher values linearly affect time required."
+                    ToolTipService.ShowOnDisabled="True"
             />
+        </StackPanel>
+        <Button Command="{Binding ChangeBredPals}" Height="20">Allowed Bred Pals</Button>
     </StackPanel>
 
     <StackPanel Margin="10,0" VerticalAlignment="Center">

--- a/PalCalc.UI/ViewModel/BreedingResultViewModel.cs
+++ b/PalCalc.UI/ViewModel/BreedingResultViewModel.cs
@@ -31,6 +31,7 @@ namespace PalCalc.UI.ViewModel
                 maxBreedingSteps: 3,
                 maxWildPals: 0,
                 allowedWildPals: PalDB.LoadEmbedded().Pals.ToList(),
+                bannedBredPals: new List<Pal>(),
                 maxInputIrrelevantTraits: 2,
                 maxBredIrrelevantTraits: 0,
                 maxEffort: TimeSpan.FromHours(8),

--- a/PalCalc.UI/ViewModel/SolverControlsViewModel.cs
+++ b/PalCalc.UI/ViewModel/SolverControlsViewModel.cs
@@ -22,6 +22,21 @@ namespace PalCalc.UI.ViewModel
             MaxInputIrrelevantTraits = 2;
             MaxBredIrrelevantTraits = 1;
 
+            ChangeBredPals = new RelayCommand(() =>
+            {
+                var window = new PalCheckListWindow();
+                window.DataContext = new PalCheckListViewModel(
+                    onCancel: null,
+                    onSave: (palSelections) => BannedBredPals = palSelections.Where(kvp => !kvp.Value).Select(kvp => kvp.Key).ToList(),
+                    initialState: PalDB.LoadEmbedded().Pals.ToDictionary(p => p, p => !BannedBredPals.Contains(p))
+                )
+                {
+                    Title = "Allowed Bred Pals"
+                };
+                window.Owner = App.Current.MainWindow;
+                window.ShowDialog();
+            });
+
             ChangeWildPals = new RelayCommand(() =>
             {
                 var window = new PalCheckListWindow();
@@ -83,7 +98,11 @@ namespace PalCalc.UI.ViewModel
         [ObservableProperty]
         private bool canEditSettings = true;
 
+        public IRelayCommand ChangeBredPals { get; }
         public IRelayCommand ChangeWildPals { get; }
+
+        [ObservableProperty]
+        private List<Pal> bannedBredPals = new List<Pal>();
 
         [ObservableProperty]
         private List<Pal> bannedWildPals = new List<Pal>();
@@ -96,6 +115,7 @@ namespace PalCalc.UI.ViewModel
             MaxBreedingSteps,
             MaxWildPals,
             allowedWildPals: PalDB.LoadEmbedded().Pals.Except(BannedWildPals).ToList(),
+            bannedBredPals: BannedBredPals,
             MaxInputIrrelevantTraits,
             MaxBredIrrelevantTraits,
             TimeSpan.MaxValue,
@@ -109,6 +129,7 @@ namespace PalCalc.UI.ViewModel
             MaxInputIrrelevantTraits = MaxInputIrrelevantTraits,
             MaxBredIrrelevantTraits = MaxBredIrrelevantTraits,
             MaxThreads = MaxThreads,
+            BannedBredPalInternalNames = BannedBredPals.Select(p => p.InternalName).ToList(),
             BannedWildPalInternalNames = BannedWildPals.Select(p => p.InternalName).ToList(),
         };
 
@@ -120,6 +141,7 @@ namespace PalCalc.UI.ViewModel
             MaxBredIrrelevantTraits = model.MaxBredIrrelevantTraits,
             MaxThreads = model.MaxThreads,
             
+            BannedBredPals = model.BannedBredPals(PalDB.LoadEmbedded()),
             BannedWildPals = model.BannedWildPals(PalDB.LoadEmbedded()),
         };
     }


### PR DESCRIPTION
This option is useful for players who are still trying to get 12 of each Pal and want to try to breed something else on the way towards their final goal. For example, if your breeding path includes Celaray and you already have too many of them, you can remove it from the Allowed Bred Pals list to try to get something you haven't yet caught 12 of.