### PR TITLE
Bugfix: Remote Filesystem Save Reload Button Visibility

### DIFF
--- a/PalCalc.UI/ViewModel/Mapped/SaveGameViewModel.cs
+++ b/PalCalc.UI/ViewModel/Mapped/SaveGameViewModel.cs
@@ -82,7 +82,10 @@ namespace PalCalc.UI.ViewModel.Mapped
                 App.Current.Dispatcher.BeginInvoke(() =>
                 {
                     ReadSaveDescription();
-                    HasChanges = false;
+                    if (changedSave.IsLocal)
+                        HasChanges = false;
+                    else 
+                        HasChanges = true;
                 });
             }
         }


### PR DESCRIPTION
The Filesystem Watcher functionality has well known issues with non-local filesystem monitoring. This leads to not reliably being able to notify on changes when monitoring remote filesystem locations. 

In order to compensate for this, a IsLocal flag has been added to the ISaveGame interface that is sued to report if the path passed in for a save is located on a local or remote filessytem. 

Using the IsLocal flag, a check was added to the reset of the HasChanges flag in the RespondToChanges function of the SaveGameViewModel class to simulate that the save game located on a remote filesystem always has changes.

This leaves the base functionality for filesystem watching intact for any paths determined to be on the local machine running the application but allows remote filesystem locations to be reloaded at will.