### PR TITLE
Scrape breeding inheritance constants from game files

### DIFF
--- a/PalCalc.GenDB/BuildDBProgram.cs
+++ b/PalCalc.GenDB/BuildDBProgram.cs
@@ -717,6 +717,16 @@ namespace PalCalc.GenDB
             provider.Mount();
             provider.LoadVirtualPaths();
 
+            // quick diagnostic: verify GameSettingReader against real game files without a full DB build
+            if (args.Contains("--dump-inheritance"))
+            {
+                var gs = GameSettingReader.ReadGameSettings(provider);
+                logger.Information("Combi_TalentInheritNum    = [{v}]", string.Join(", ", gs?.TalentInheritNum ?? new List<int>()));
+                logger.Information("Combi_PassiveInheritNum   = [{v}]", string.Join(", ", gs?.PassiveInheritNum ?? new List<int>()));
+                logger.Information("Combi_PassiveRandomAddNum = [{v}]", string.Join(", ", gs?.PassiveRandomAddNum ?? new List<int>()));
+                return;
+            }
+
             logger.Information("Reading localizations, pals, and passives...");
             var localizations = LocalizationsReader.FetchLocalizations(provider);
 
@@ -793,6 +803,11 @@ namespace PalCalc.GenDB
                 p => p,
                 p => genderProbabilities[p.InternalName]
             );
+
+            var rawGameSettings = GameSettingReader.ReadGameSettings(provider);
+            db.CombiTalentInheritNum = rawGameSettings?.TalentInheritNum;
+            db.CombiPassiveInheritNum = rawGameSettings?.PassiveInheritNum;
+            db.CombiPassiveRandomAddNum = rawGameSettings?.PassiveRandomAddNum;
 
             File.WriteAllText("../PalCalc.Model/db.json", db.ToJson());
 

--- a/PalCalc.GenDB/GameDataReaders/GameSettingReader.cs
+++ b/PalCalc.GenDB/GameDataReaders/GameSettingReader.cs
@@ -1,0 +1,72 @@
+﻿using CUE4Parse.FileProvider;
+using CUE4Parse.UE4.Assets.Exports;
+using CUE4Parse.UE4.Assets.Objects;
+using Serilog;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace PalCalc.GenDB.GameDataReaders
+{
+    public class RawGameSettings
+    {
+        // weight arrays governing breeding inheritance (see PalCalc.Model.GameConstants)
+        public List<int> TalentInheritNum { get; set; }
+        public List<int> PassiveInheritNum { get; set; }
+        public List<int> PassiveRandomAddNum { get; set; }
+    }
+
+    internal class GameSettingReader
+    {
+        private static ILogger logger = Log.ForContext<GameSettingReader>();
+
+        public static RawGameSettings ReadGameSettings(IFileProvider provider)
+        {
+            // The values live on the PalGameSetting CDO (BP_PalGameSetting). We don't hardcode the
+            // exact asset path — instead scan any "PalGameSetting" asset for the export that actually
+            // carries `Combi_TalentInheritNum`, which is robust to path/name changes across versions.
+            var candidates = provider.Files
+                .Where(kvp => kvp.Key.EndsWith(".uasset", StringComparison.OrdinalIgnoreCase)
+                           && kvp.Key.Contains("PalGameSetting", StringComparison.OrdinalIgnoreCase));
+
+            foreach (var kvp in candidates)
+            {
+                if (!provider.TryLoadPackage(kvp.Value, out var ipkg))
+                    continue;
+
+                foreach (var obj in ipkg.GetExports())
+                {
+                    if (!obj.Properties.Any(p => p.Name.Text == "Combi_TalentInheritNum"))
+                        continue;
+
+                    logger.Information("Reading breeding inheritance settings from {path}", kvp.Key);
+                    return new RawGameSettings()
+                    {
+                        TalentInheritNum = ReadIntArray(obj, "Combi_TalentInheritNum"),
+                        PassiveInheritNum = ReadIntArray(obj, "Combi_PassiveInheritNum"),
+                        PassiveRandomAddNum = ReadIntArray(obj, "Combi_PassiveRandomAddNum"),
+                    };
+                }
+            }
+
+            logger.Warning("Could not find PalGameSetting with Combi_TalentInheritNum; inheritance constants will use datamined defaults.");
+            return null;
+        }
+
+        private static List<int> ReadIntArray(UObject obj, string name)
+        {
+            var prop = obj.Properties.FirstOrDefault(p => p.Name.Text == name);
+            if (prop == null)
+            {
+                logger.Warning("PalGameSetting property {name} not found", name);
+                return null;
+            }
+
+            var arr = prop.Tag?.GetValue<UScriptArray>();
+            if (arr == null) return null;
+
+            // stored as floats (e.g. 3.0, 2.0, 1.0); these are integer weights
+            return arr.Properties.Select(p => (int)Math.Round(p.GetValue<float>())).ToList();
+        }
+    }
+}

--- a/PalCalc.Model.Tests/GameConstantsTests.cs
+++ b/PalCalc.Model.Tests/GameConstantsTests.cs
@@ -1,0 +1,41 @@
+namespace PalCalc.Model.Tests
+{
+    [TestClass]
+    public class GameConstantsTests
+    {
+        // Pins the inheritance distributions computed from the datamined weight arrays.
+        // Combi_TalentInheritNum = [3,2,1]; Combi_PassiveInheritNum = Combi_PassiveRandomAddNum = [4,3,2,1].
+        private const float Tol = 0.0001f;
+
+        [TestMethod]
+        public void IVProbabilityDirect_MatchesDataminedWeights()
+        {
+            // [3,2,1] -> 50% / 33.3% / 16.7% (NOT the old hand-typed 50/25/25)
+            Assert.AreEqual(3f / 6f, GameConstants.IVProbabilityDirect[1], Tol);
+            Assert.AreEqual(2f / 6f, GameConstants.IVProbabilityDirect[2], Tol);
+            Assert.AreEqual(1f / 6f, GameConstants.IVProbabilityDirect[3], Tol);
+        }
+
+        [TestMethod]
+        public void PassiveProbabilityDirect_MatchesDataminedWeights()
+        {
+            // [4,3,2,1] -> 40 / 30 / 20 / 10
+            Assert.AreEqual(0.40f, GameConstants.PassiveProbabilityDirect[1], Tol);
+            Assert.AreEqual(0.30f, GameConstants.PassiveProbabilityDirect[2], Tol);
+            Assert.AreEqual(0.20f, GameConstants.PassiveProbabilityDirect[3], Tol);
+            Assert.AreEqual(0.10f, GameConstants.PassiveProbabilityDirect[4], Tol);
+        }
+
+        [TestMethod]
+        public void CumulativeTables_AreReverseCumulativeOfExact()
+        {
+            Assert.AreEqual(1.00f, GameConstants.PassiveProbabilityAtLeastN[1], Tol);
+            Assert.AreEqual(0.60f, GameConstants.PassiveProbabilityAtLeastN[2], Tol);
+            Assert.AreEqual(0.30f, GameConstants.PassiveProbabilityAtLeastN[3], Tol);
+            Assert.AreEqual(0.10f, GameConstants.PassiveProbabilityAtLeastN[4], Tol);
+
+            Assert.AreEqual(1.00f, GameConstants.PassiveRandomAddedAtLeastN[0], Tol);
+            Assert.AreEqual(0.60f, GameConstants.PassiveRandomAddedAtLeastN[1], Tol);
+        }
+    }
+}

--- a/PalCalc.Model/GameConstants.cs
+++ b/PalCalc.Model/GameConstants.cs
@@ -56,16 +56,98 @@ namespace PalCalc.Model
 
         // (note: changing these from dictionaries to arrays has negligible impact on performance. dictionaries are more legible in this case)
 
-        // probability of inheriting exactly N IVs from parents
-        public static readonly Dictionary<int, float> IVProbabilityDirect = new()
+        // === Inheritance probability tables ===
+        //
+        // Derived from the game's raw weight arrays in `PalGameSetting` (scraped by PalCalc.GenDB):
+        //   Combi_TalentInheritNum    -> how many IVs are copied from parents
+        //   Combi_PassiveInheritNum   -> how many passives are copied from parents
+        //   Combi_PassiveRandomAddNum -> how many random passives are added
+        //
+        // A weight array [w0, w1, ...] over outcomes {c, c+1, ...} gives P(k) = w / sum(w).
+        // e.g. Combi_TalentInheritNum = [3,2,1] -> inherit 1/2/3 IVs at 50% / 33.3% / 16.7%.
+        //
+        // The raw arrays are scraped into db.json and applied at load via ApplyScrapedInheritance().
+        // The defaults below are the datamined values, used as a fallback if a db.json predates scraping.
+        // (datamined from BP_PalGameSetting, Steam build 24181527, 2026-07)
+        private static IReadOnlyList<int> talentInheritWeights = new[] { 3, 2, 1 };
+        private static IReadOnlyList<int> passiveInheritWeights = new[] { 4, 3, 2, 1 };
+        private static IReadOnlyList<int> passiveRandomAddWeights = new[] { 4, 3, 2, 1 };
+
+        // probability of inheriting exactly N IVs from parents (always inherits at least 1)
+        public static IReadOnlyDictionary<int, float> IVProbabilityDirect { get; private set; }
+        // probability of ending up with N desired IVs, indexed [numDesired - 1]
+        public static IReadOnlyList<float> IVDesiredProbabilities { get; private set; }
+
+        // probability of inheriting exactly / at least N passives from the parent pool
+        public static IReadOnlyDictionary<int, float> PassiveProbabilityDirect { get; private set; }
+        public static IReadOnlyDictionary<int, float> PassiveProbabilityAtLeastN { get; private set; }
+        // probability of adding exactly / at least N random passives
+        public static IReadOnlyDictionary<int, float> PassiveRandomAddedProbability { get; private set; }
+        public static IReadOnlyDictionary<int, float> PassiveRandomAddedAtLeastN { get; private set; }
+
+        static GameConstants() => RecomputeInheritanceTables();
+
+        /// <summary>
+        /// Overrides the raw inheritance weight arrays with values scraped from game files
+        /// (see PalCalc.GenDB.GameSettingReader). Null/empty arguments keep the datamined defaults.
+        /// </summary>
+        public static void ApplyScrapedInheritance(
+            IReadOnlyList<int> talentInherit,
+            IReadOnlyList<int> passiveInherit,
+            IReadOnlyList<int> passiveRandomAdd)
         {
-            // will always inherit at least 1
-            { 0, 0.0f },
-            // (determined manually by gathering samples, unlike passive probabilities which were reverse engineered)
-            { 1, 0.5f },
-            { 2, 0.25f },
-            { 3, 0.25f },
-        };
+            if (talentInherit is { Count: > 0 }) talentInheritWeights = talentInherit;
+            if (passiveInherit is { Count: > 0 }) passiveInheritWeights = passiveInherit;
+            if (passiveRandomAdd is { Count: > 0 }) passiveRandomAddWeights = passiveRandomAdd;
+            RecomputeInheritanceTables();
+        }
+
+        private static void RecomputeInheritanceTables()
+        {
+            // exact-count distributions
+            IVProbabilityDirect = WithKey(DistFromWeights(talentInheritWeights, startCount: 1), 0);
+            PassiveProbabilityDirect = WithKey(DistFromWeights(passiveInheritWeights, startCount: 1), 0);
+            PassiveRandomAddedProbability = WithKey(DistFromWeights(passiveRandomAddWeights, startCount: 0), MaxTotalPassives);
+
+            // cumulative "at least N"
+            PassiveProbabilityAtLeastN = AtLeast(DistFromWeights(passiveInheritWeights, startCount: 1));
+            PassiveRandomAddedAtLeastN = AtLeast(PassiveRandomAddedProbability);
+
+            // IV desired-count probabilities: chance of getting `numDesired` specific IVs given the
+            // inherited-count distribution. combinations table is fixed (there are 3 IV stats).
+            var comb = new Dictionary<int, Dictionary<int, float>>()
+            {
+                { 1, new() { { 1, 1f / 3f }, { 2, 0f },      { 3, 0f } } },
+                { 2, new() { { 1, 2f / 3f }, { 2, 1f / 3f }, { 3, 0f } } },
+                { 3, new() { { 1, 1f },      { 2, 1f },      { 3, 1f } } },
+            };
+            var ivDesired = new float[3];
+            for (int numInherited = 1; numInherited <= 3; numInherited++)
+                for (int numDesired = 1; numDesired <= 3; numDesired++)
+                    ivDesired[numDesired - 1] += IVProbabilityDirect[numInherited] * comb[numInherited][numDesired];
+            IVDesiredProbabilities = ivDesired;
+        }
+
+        // weights[i] is the weight for outcome (startCount + i); P(outcome) = weight / sum
+        private static Dictionary<int, float> DistFromWeights(IReadOnlyList<int> weights, int startCount)
+        {
+            float sum = weights.Sum();
+            var d = new Dictionary<int, float>();
+            for (int i = 0; i < weights.Count; i++)
+                d[startCount + i] = weights[i] / sum;
+            return d;
+        }
+
+        // ensure `key` exists (probability 0) so consumers can index it safely
+        private static Dictionary<int, float> WithKey(Dictionary<int, float> dist, int key)
+        {
+            if (!dist.ContainsKey(key)) dist[key] = 0.0f;
+            return dist;
+        }
+
+        // P(X >= k) for each k present in the exact-count distribution
+        private static Dictionary<int, float> AtLeast(IReadOnlyDictionary<int, float> exact) =>
+            exact.Keys.ToDictionary(k => k, k => exact.Where(kv => kv.Key >= k).Sum(kv => kv.Value));
 
         // roughly estimate time to catch a given pal
         public static TimeSpan TimeToCatch(Pal pal)
@@ -101,59 +183,8 @@ namespace PalCalc.Model
               ],
         */
 
-        // probability of getting N passives from parent pool
-        public static readonly IReadOnlyDictionary<int, float> PassiveProbabilityDirect = new Dictionary<int, float>()
-        {
-            { 4, 0.10f },
-            { 3, 0.20f },
-            { 2, 0.30f },
-            { 1, 0.40f },
-            { 0, 0.0f },
-        };
-
-        // probability of getting N passives from parent pool without any random passives
-        public static readonly IReadOnlyDictionary<int, float> PassiveProbabilityNoRandom = new Dictionary<int, float>()
-        {
-            { 4, 0.10f },
-            { 3, 0.08f },
-            { 2, 0.12f },
-            { 1, 0.16f },
-        };
-
-        public static readonly IReadOnlyDictionary<int, float> PassiveProbabilityAtLeastN = new Dictionary<int, float>()
-        {
-            { 4, 0.10f },
-            { 3, 0.30f },
-            { 2, 0.60f },
-            { 1, 1.00f },
-        };
-
-        public static readonly IReadOnlyDictionary<int, float> PassiveProbabilityNoRandomAtLeastN = new Dictionary<int, float>()
-        {
-            { 4, 0.10f },
-            { 3, 0.12f },
-            { 2, 0.24f },
-            { 1, 0.40f },
-        };
-
-        // probability of getting N additional random passives added
-        public static readonly IReadOnlyDictionary<int, float> PassiveRandomAddedProbability = new Dictionary<int, float>()
-        {
-            { 4, 0.0f },
-            { 3, 0.10f },
-            { 2, 0.20f },
-            { 1, 0.30f },
-            { 0, 0.40f },
-        };
-
-        public static readonly IReadOnlyDictionary<int, float> PassiveRandomAddedAtLeastN = new Dictionary<int, float>()
-        {
-            { 4, 0.0f },
-            { 3, 0.10f },
-            { 2, 0.3f },
-            { 1, 0.6f },
-            { 0, 1.0f }
-        };
+        // (PassiveProbabilityDirect / AtLeastN and PassiveRandomAdded* are now computed from the
+        //  scraped weight arrays — see the inheritance tables section above)
 
         // probability of a wild pal having, at most, N random passives
         // (assume equal probability of gaining anywhere from 0 through 4 random passives)

--- a/PalCalc.Model/JsonConverters.cs
+++ b/PalCalc.Model/JsonConverters.cs
@@ -197,6 +197,10 @@ namespace PalCalc.Model
                     kvp => kvp.Key.InternalToPal(pals),
                     kvp => kvp.Value
                 ),
+
+                CombiTalentInheritNum = asToken["CombiTalentInheritNum"]?.ToObject<List<int>>(),
+                CombiPassiveInheritNum = asToken["CombiPassiveInheritNum"]?.ToObject<List<int>>(),
+                CombiPassiveRandomAddNum = asToken["CombiPassiveRandomAddNum"]?.ToObject<List<int>>(),
             };
         }
 
@@ -211,6 +215,9 @@ namespace PalCalc.Model
                 ActiveSkills = value.ActiveSkills,
                 Elements = value.Elements,
                 BreedingGenderProbability = value.BreedingGenderProbability.ToDictionary(kvp => kvp.Key.InternalName, kvp => kvp.Value),
+                CombiTalentInheritNum = value.CombiTalentInheritNum,
+                CombiPassiveInheritNum = value.CombiPassiveInheritNum,
+                CombiPassiveRandomAddNum = value.CombiPassiveRandomAddNum,
             }).WriteTo(writer);
         }
     }

--- a/PalCalc.Model/PalDB.cs
+++ b/PalCalc.Model/PalDB.cs
@@ -37,6 +37,12 @@ namespace PalCalc.Model
         public List<PalElement> Elements { get; set; }
         public List<ActiveSkill> ActiveSkills { get; set; }
 
+        // raw inheritance weight arrays scraped from PalGameSetting (see GameConstants + GenDB.GameSettingReader).
+        // null in DBs generated before scraping was added; GameConstants falls back to datamined defaults.
+        public List<int> CombiTalentInheritNum { get; set; }
+        public List<int> CombiPassiveInheritNum { get; set; }
+        public List<int> CombiPassiveRandomAddNum { get; set; }
+
         public IEnumerable<Pal> Pals => PalsById.Values;
 
         private Dictionary<string, PassiveSkill> standardPassiveSkillsByName;
@@ -90,6 +96,9 @@ namespace PalCalc.Model
             PalDB result;
             using (var streamReader = new StreamReader(stream, Encoding.UTF8))
                 result = FromJson(streamReader.ReadToEnd());
+
+            // apply scraped inheritance weights (falls back to datamined defaults if absent)
+            GameConstants.ApplyScrapedInheritance(result.CombiTalentInheritNum, result.CombiPassiveInheritNum, result.CombiPassiveRandomAddNum);
 
             logger.Information("Successfully loaded embedded pal DB in {ms}ms", sw.ElapsedMilliseconds);
             return result;

--- a/PalCalc.Solver/Probabilities/IVs.cs
+++ b/PalCalc.Solver/Probabilities/IVs.cs
@@ -11,70 +11,9 @@ namespace PalCalc.Solver.Probabilities
     // https://github.com/tylercamp/palcalc/issues/22#issuecomment-2509171056
     public static class IVs
     {
-        // [NumDesired - 1]
-        // eg if there's 1 specific type of IV we want, then ivDP[0] gives the probability of getting that IV
-        // (not including 50/50 chance of inheriting from specific parent)
-        private static float[] ivDesiredProbabilities;
-
-        static IVs()
-        {
-            // for IV inheritance there's the probability of:
-            //
-            // 1. the chance of inheriting exactly N IVs
-            // 2. the chance of those IVs being what we want
-
-            // (1) is stored in GameConstants and can change depending on game updates
-            // (2) is represented in `combinationsProbabilityTable` and is just from the possible combinations,
-            //     regardless of game logic
-
-            var combinationsProbabilityTable = new Dictionary<int, Dictionary<int, float>>()
-            {
-                // 1 inherited
-                { 1, new() {
-                    { 1, 1.0f / 3.0f }, // 1 desired
-                    { 2, 0.0f },        // 2 desired (no way to get 2 if we only inherited 1)
-                    { 3, 0.0f },        // 3 desired (...)
-                } },
-
-                // 2 inherited
-                { 2, new() {
-                    { 1, 2.0f / 3.0f }, // 1 desired
-                    { 2, 1.0f / 3.0f }, // 2 desired
-                    { 3, 0.0f }         // 3 desired (no way to get 3 if we only inherited 2
-                } },
-
-                // 3 inherited
-                { 3, new() {
-                    // 3 inherited means all IVs inherited, doesn't matter what IV we actually wanted, we'll always get it
-                    { 1, 1.0f },
-                    { 2, 1.0f },
-                    { 3, 1.0f }
-                } }
-            };
-
-            /*
-            IV probabilities have similar approach as `Passives.ProbabilityInheritedTargetPassives` - a pal will end up inheriting
-            exactly 1, 2, or 3 IVs; get the probability of each case combined with the probability of those cases giving us
-            what we want
-            */
-
-            // stores the final probabilities of getting some number of desired IVs
-            //
-            // (the final real probability will also need to account for 50/50 chance of inheriting the IV from either specific parent)
-            ivDesiredProbabilities = new float[3];
-            for (int i = 0; i < 3; i++) ivDesiredProbabilities[i] = 0.0f;
-
-            for (int numInherited = 1; numInherited <= 3; numInherited++)
-            {
-                var probabilityInherited = GameConstants.IVProbabilityDirect[numInherited];
-                for (int numDesired = 1; numDesired <= 3; numDesired++)
-                {
-                    var probabilityMatched = combinationsProbabilityTable[numInherited][numDesired];
-
-                    ivDesiredProbabilities[numDesired - 1] += probabilityInherited * probabilityMatched;
-                }
-            }
-        }
+        // The probability of ending up with N desired IVs (indexed [numDesired - 1]) is computed
+        // centrally in GameConstants.IVDesiredProbabilities, from the scraped inherited-count
+        // distribution. (Does not include the 50/50 chance of inheriting from a specific parent.)
 
         /// <summary>
         /// Given the IVs from two parents, returns the probability of inheriting all desired IVs from the parents.
@@ -103,7 +42,7 @@ namespace PalCalc.Solver.Probabilities
             if (numRequiredIVs == 0) return 1.0f;
 
             // base probability is the chance of getting the IV categories we want
-            float result = ivDesiredProbabilities[numRequiredIVs - 1];
+            float result = GameConstants.IVDesiredProbabilities[numRequiredIVs - 1];
 
             // even if we got the right IV categories, we might not get the right parents/values
             //


### PR DESCRIPTION
# Scrape breeding inheritance constants from game files

**TL;DR:** Found the IV inheritance odds had drifted from the game's real value.
Fixed it by scraping the numbers from game files - like every other value -
instead of hand-typing them.

## What I found

`IVProbabilityDirect` (how many IVs a child copies from parents) was hardcoded
`50 / 25 / 25`, with a comment: *"determined manually by gathering samples."*

The game's own setting says otherwise. `PalGameSetting.Combi_TalentInheritNum`:

```
[3, 2, 1]   →   50% / 33.3% / 16.7%
```

Only the 2-IV / 3-IV split was wrong. (The passive tables are correct - they match `Combi_PassiveInheritNum = [4,3,2,1]`.)

## Why not just change the number?
These constants are the **only** game-derived numbers
that aren't scraped - everything else (Pals, skills, even gender odds) flows
`game files → db.json → app`. So I put these on the same pipeline.

## What changed

| | |
|---|---|
| `GameSettingReader` | reads the `Combi_*` weight arrays from `PalGameSetting` (mirrors `PartnerSkillReader`) |
| `PalDB` + converter | carries the arrays through `db.json` (like `BreedingGenderProbability`) |
| `GameConstants` | **computes** the distributions from the raw arrays instead of hand-typed literals; applied at DB load, datamined defaults as fallback |
| `IVs` | reads the centralized `GameConstants.IVDesiredProbabilities` |

## Effect

- With an IV target: "get all 3 IVs" is correctly **16.7%** (was 25%); this can
  reorder the optimal route. No change when no IV target is set.
- `GameConstants` also drops two dead tables and the hand-typed derived tables.

## Tests

- Existing IV/passive probability tests pass **unchanged** (they read the
  constants symbolically).
- Adds `GameConstantsTests` pinning the datamined distributions.
- tyler's existing tests pass unchanged (Solver 99, Model 9) - plus a new GameConstantsTests pinning the datamined values.

---

**A note on how this was made:** I leaned heavily on AI for the C# - it's not my
strong suit. The mechanics research, the datamine, and the testing are all real
and verified end-to-end against the game files, but if AI-assisted PRs aren't
something you want to merge, no worries at all - feel free to close it. Thanks
either way for PalCalc, it's a great tool. 🙂

<details>
<summary>GenDB verified end-to-end against real game files</summary>

Ran `BuildDBProgram --dump-inheritance` against the shipping paks + a UE4SS-generated
`Mappings.usmap`:

```
Reading breeding inheritance settings from Pal/Content/Pal/Blueprint/System/BP_PalGameSetting.uasset
Combi_TalentInheritNum    = [3, 2, 1]
Combi_PassiveInheritNum   = [4, 3, 2, 1]
Combi_PassiveRandomAddNum = [4, 3, 2, 1]
```

The reader scans for any `PalGameSetting` asset carrying `Combi_TalentInheritNum`
rather than hardcoding a path, so it's robust to path changes. The committed
`db.json` is unchanged; it picks up the scraped arrays on the next full
`BuildDBProgram` run. Until then the datamined defaults apply, so the fix is
live immediately.

</details>
