### PR TITLE
Remember window layout between sessions (#212)

### DIFF
--- a/PalCalc.UI.Tests/PalCalc.UI.Tests.csproj
+++ b/PalCalc.UI.Tests/PalCalc.UI.Tests.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0-windows10.0.17763.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+    <UseWPF>true</UseWPF>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MSTest" Version="4.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\PalCalc.UI\PalCalc.UI.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
+  </ItemGroup>
+
+</Project>

--- a/PalCalc.UI.Tests/WindowStatePersistenceTests.cs
+++ b/PalCalc.UI.Tests/WindowStatePersistenceTests.cs
@@ -1,0 +1,95 @@
+using System.Collections.Generic;
+using System.Windows;
+using System.Windows.Controls;
+using Newtonsoft.Json;
+using PalCalc.UI.Model;
+
+namespace PalCalc.UI.Tests
+{
+    [TestClass]
+    public class WindowStatePersistenceTests
+    {
+        [TestMethod]
+        public void Columns_PreservePixelAndStarUnits()
+        {
+            var cols = new List<ColumnDefinition>
+            {
+                new() { Width = new GridLength(300) },
+                new() { Width = new GridLength(232, GridUnitType.Star) },
+                new() { Width = new GridLength(80, GridUnitType.Star) },
+            };
+
+            var saved = WindowStatePersistence.SaveColumns(cols);
+
+            var restored = new List<ColumnDefinition>
+            {
+                new() { Width = new GridLength(1) },
+                new() { Width = new GridLength(1) },
+                new() { Width = new GridLength(1) },
+            };
+            WindowStatePersistence.ApplyColumns(restored, saved);
+
+            Assert.AreEqual(new GridLength(300), restored[0].Width);
+            Assert.AreEqual(new GridLength(232, GridUnitType.Star), restored[1].Width);
+            Assert.AreEqual(new GridLength(80, GridUnitType.Star), restored[2].Width);
+        }
+
+        [TestMethod]
+        public void Columns_PreserveAutoUnit()
+        {
+            var cols = new List<ColumnDefinition> { new() { Width = GridLength.Auto } };
+            var saved = WindowStatePersistence.SaveColumns(cols);
+
+            var restored = new List<ColumnDefinition> { new() { Width = new GridLength(50) } };
+            WindowStatePersistence.ApplyColumns(restored, saved);
+
+            Assert.AreEqual(GridLength.Auto, restored[0].Width);
+        }
+
+        [TestMethod]
+        public void ApplyColumns_IgnoresCountMismatch()
+        {
+            var cols = new List<ColumnDefinition> { new() { Width = new GridLength(1) } };
+            WindowStatePersistence.ApplyColumns(cols, new List<string> { "10", "20" });
+            Assert.AreEqual(new GridLength(1), cols[0].Width);
+        }
+
+        [TestMethod]
+        public void ApplyColumns_NullIsNoOp()
+        {
+            var cols = new List<ColumnDefinition> { new() { Width = new GridLength(5) } };
+            WindowStatePersistence.ApplyColumns(cols, null);
+            Assert.AreEqual(new GridLength(5), cols[0].Width);
+        }
+
+        [TestMethod]
+        public void UILayouts_RoundTripsThroughJson()
+        {
+            var settings = new AppSettings();
+            settings.UILayouts["main"] = new WindowLayoutState
+            {
+                Left = 100, Top = 50, Width = 1280, Height = 720, Maximized = true
+            };
+            settings.UILayouts["solver"] = new WindowLayoutState
+            {
+                ColumnWidths = new List<string> { "300", "232*", "80*" }
+            };
+
+            var json = JsonConvert.SerializeObject(settings);
+            var back = JsonConvert.DeserializeObject<AppSettings>(json);
+
+            Assert.AreEqual(100, back.UILayouts["main"].Left);
+            Assert.AreEqual(720, back.UILayouts["main"].Height);
+            Assert.AreEqual(true, back.UILayouts["main"].Maximized);
+            CollectionAssert.AreEqual(
+                new[] { "300", "232*", "80*" },
+                back.UILayouts["solver"].ColumnWidths);
+        }
+
+        [TestMethod]
+        public void UILayouts_DefaultsToEmptyNotNull()
+        {
+            Assert.IsNotNull(new AppSettings().UILayouts);
+        }
+    }
+}

--- a/PalCalc.UI/AppWindow.xaml.cs
+++ b/PalCalc.UI/AppWindow.xaml.cs
@@ -43,6 +43,9 @@ namespace PalCalc.UI
         {
             DataContext = new AppWindowViewModel(Dispatcher);
             InitializeComponent();
+            SourceInitialized += (_, _) => WindowStatePersistence.RestoreMainWindow(this);
+            Closing += (_, _) => WindowStatePersistence.SaveMainWindow(
+                this, (DataContext as AppWindowViewModel)?.Content is SolverPage);
         }
     }
 }

--- a/PalCalc.UI/Localization/LocalizationCodes.Designer.cs
+++ b/PalCalc.UI/Localization/LocalizationCodes.Designer.cs
@@ -66,6 +66,10 @@ namespace PalCalc.UI.Localization {
         /// </summary>
         LC_ABOUT_APP,
         /// <summary>
+        ///   Looks up a localized string similar to Reset Window Layout.
+        /// </summary>
+        LC_RESET_LAYOUT,
+        /// <summary>
         ///   Looks up a localized string similar to .
         /// </summary>
         LC_ADD_FAKE_SAVE,

--- a/PalCalc.UI/Localization/LocalizationCodes.resx
+++ b/PalCalc.UI/Localization/LocalizationCodes.resx
@@ -120,6 +120,9 @@
   <data name="LC_ABOUT_APP" xml:space="preserve">
     <value />
   </data>
+  <data name="LC_RESET_LAYOUT" xml:space="preserve">
+    <value />
+  </data>
   <data name="LC_ADD_NEW_SAVE" xml:space="preserve">
     <value />
   </data>

--- a/PalCalc.UI/Localization/Localizations/en.resx
+++ b/PalCalc.UI/Localization/Localizations/en.resx
@@ -120,6 +120,9 @@
   <data name="LC_ABOUT_APP" xml:space="preserve">
     <value>About Pal Calc</value>
   </data>
+  <data name="LC_RESET_LAYOUT" xml:space="preserve">
+    <value>Reset Window Layout</value>
+  </data>
   <data name="LC_ADD_FAKE_SAVE" xml:space="preserve">
     <value>Add a fake save...</value>
   </data>

--- a/PalCalc.UI/Model/AppSettings.cs
+++ b/PalCalc.UI/Model/AppSettings.cs
@@ -59,9 +59,28 @@ namespace PalCalc.UI.Model
         public List<string> ColumnOrder { get; set; } = new();
     }
 
+    public class WindowLayoutState
+    {
+        // GridLength strings ("300", "232*") for the resizable columns, in column order. Null when unused.
+        public List<string> ColumnWidths { get; set; }
+        // GridLength strings for the resizable rows, in row order. Null when unused.
+        public List<string> RowHeights { get; set; }
+
+        // Main-window layout (WPF DIPs). Position + maximized are remembered on every screen;
+        // Width/Height (the resizable size) are remembered only from the solver page.
+        public double? Left { get; set; }
+        public double? Top { get; set; }
+        public double? Width { get; set; }
+        public double? Height { get; set; }
+        public bool? Maximized { get; set; }
+    }
+
     public class AppSettings
     {
         public static AppSettings Current = null;
+
+        // Keyed by a stable UI id ("main", "solver", "saveInspector", "saveDetails", "search").
+        public Dictionary<string, WindowLayoutState> UILayouts { get; set; } = new();
 
         public List<string> ExtraSaveLocations { get; set; } = [];
 

--- a/PalCalc.UI/Model/WindowStatePersistence.cs
+++ b/PalCalc.UI/Model/WindowStatePersistence.cs
@@ -1,0 +1,235 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+
+namespace PalCalc.UI.Model
+{
+    // Persists window position/size/maximized-state (in WPF DIPs; Aero-snapped bounds are
+    // captured because ActualWidth/Left reflect them) and resizable grid column/row sizes,
+    // keyed into AppSettings.UILayouts.
+    public static class WindowStatePersistence
+    {
+        // ---- Column widths ----
+
+        private static readonly GridLengthConverter GridConv = new();
+
+        public static List<string> SaveColumns(IEnumerable<ColumnDefinition> cols) =>
+            cols.Select(c => GridConv.ConvertToString(c.Width)).ToList();
+
+        public static List<string> SaveRows(IEnumerable<RowDefinition> rows) =>
+            rows.Select(r => GridConv.ConvertToString(r.Height)).ToList();
+
+        public static void ApplyColumns(IReadOnlyList<ColumnDefinition> cols, List<string> widths)
+        {
+            if (widths == null || widths.Count != cols.Count) return;
+            for (int i = 0; i < cols.Count; i++)
+            {
+                try { cols[i].Width = (GridLength)GridConv.ConvertFromString(widths[i]); }
+                catch { /* leave XAML default on bad data */ }
+            }
+        }
+
+        public static void ApplyRows(IReadOnlyList<RowDefinition> rows, List<string> heights)
+        {
+            if (heights == null || heights.Count != rows.Count) return;
+            for (int i = 0; i < rows.Count; i++)
+            {
+                try { rows[i].Height = (GridLength)GridConv.ConvertFromString(heights[i]); }
+                catch { /* leave XAML default on bad data */ }
+            }
+        }
+
+        // ---- Attach helpers ----
+
+        // Remembers a window's full placement (position + size + maximized, including Aero-snapped
+        // bounds) across restarts.
+        public static void AttachWindow(Window window, string key)
+        {
+            window.SourceInitialized += (_, _) =>
+            {
+                var s = Layout(key);
+                if (s == null) return;
+                if (s.Width is double w && s.Height is double h) { window.Width = w; window.Height = h; }
+                if (s.Left is double l && s.Top is double t)
+                {
+                    // Override WindowStartupLocation (e.g. CenterOwner) so it can't re-position
+                    // the window after this point and discard the restore.
+                    window.WindowStartupLocation = WindowStartupLocation.Manual;
+                    window.Left = l;
+                    window.Top = t;
+                    ClampToScreen(window);
+                }
+                if (s.Maximized == true) window.WindowState = WindowState.Maximized;
+            };
+            window.Closing += (_, _) => SaveWindowState(window, key, rememberSize: true);
+        }
+
+        public static void AttachColumns(
+            FrameworkElement owner, string key, Func<IReadOnlyList<ColumnDefinition>> columns) =>
+            AttachGrid(owner, key, columns, null);
+
+        // Persists resizable column widths and/or row heights of a grid owned by `owner`.
+        // Saves on both Unloaded and the owning Window's Closing — Unloaded alone does NOT
+        // fire on app shutdown, so column/row state would otherwise be lost on close.
+        public static void AttachGrid(
+            FrameworkElement owner, string key,
+            Func<IReadOnlyList<ColumnDefinition>> columns = null,
+            Func<IReadOnlyList<RowDefinition>> rows = null)
+        {
+            void Restore()
+            {
+                var s = Layout(key);
+                if (columns != null) ApplyColumns(columns(), s?.ColumnWidths);
+                if (rows != null) ApplyRows(rows(), s?.RowHeights);
+            }
+
+            void Save()
+            {
+                var s = LayoutOrNew(key);
+                if (columns != null) s.ColumnWidths = SaveColumns(columns());
+                if (rows != null) s.RowHeights = SaveRows(rows());
+                Storage.SaveAppSettings(AppSettings.Current);
+            }
+
+            bool hookedWindow = false;
+            owner.Loaded += (_, _) =>
+            {
+                Restore();
+                if (!hookedWindow && Window.GetWindow(owner) is Window win)
+                {
+                    win.Closing += (_, _) => Save();
+                    hookedWindow = true;
+                }
+            };
+            owner.Unloaded += (_, _) => Save();
+        }
+
+        public static void ResetToDefault(Window window, double width, double height)
+        {
+            window.WindowState = WindowState.Normal;
+            window.Width = width;
+            window.Height = height;
+            var wa = SystemParameters.WorkArea;
+            window.Left = wa.Left + (wa.Width - width) / 2;
+            window.Top = wa.Top + (wa.Height - height) / 2;
+        }
+
+        // ---- Main window (page-aware size) ----
+
+        public const double DefaultMainWidth = 1280;
+        public const double DefaultMainHeight = 720;
+
+        // Startup opens on the save-selection screen, which always uses the default size;
+        // only position and maximized state are restored here. The remembered size is applied
+        // later by ApplySolverSize once the user reaches the solver page.
+        public static void RestoreMainWindow(Window window)
+        {
+            var s = Layout("main");
+            window.Width = DefaultMainWidth;
+            window.Height = DefaultMainHeight;
+
+            if (s?.Left is double l && s.Top is double t)
+            {
+                window.Left = l;
+                window.Top = t;
+                ClampToScreen(window);
+            }
+            else
+            {
+                CenterOnWorkArea(window);
+            }
+
+            if (s?.Maximized == true)
+                window.WindowState = WindowState.Maximized;
+        }
+
+        public static void ApplySolverSize(Window window)
+        {
+            if (window == null || window.WindowState != WindowState.Normal) return;
+            var s = Layout("main");
+            if (s?.Width is double w && s.Height is double h)
+            {
+                window.Width = w;
+                window.Height = h;
+                ClampToScreen(window);
+            }
+        }
+
+        public static void ApplyDefaultSize(Window window)
+        {
+            if (window == null || window.WindowState != WindowState.Normal) return;
+            window.Width = DefaultMainWidth;
+            window.Height = DefaultMainHeight;
+            ClampToScreen(window);
+        }
+
+        // For the main window, rememberSize is true only on the solver page (save selection keeps
+        // the default size). See AppWindowViewModel navigation.
+        public static void SaveMainWindow(Window window, bool rememberSize) =>
+            SaveWindowState(window, "main", rememberSize);
+
+        // rememberSize=false stores only position + maximized. ActualWidth/Left reflect Aero-snapped
+        // bounds while WindowState stays Normal, so snapped size/position is remembered.
+        public static void SaveWindowState(Window window, string key, bool rememberSize)
+        {
+            var s = LayoutOrNew(key);
+            if (window.WindowState == WindowState.Maximized)
+            {
+                s.Maximized = true;
+                var rb = window.RestoreBounds;
+                if (!rb.IsEmpty)
+                {
+                    s.Left = rb.Left;
+                    s.Top = rb.Top;
+                    if (rememberSize) { s.Width = rb.Width; s.Height = rb.Height; }
+                }
+            }
+            else
+            {
+                s.Maximized = false;
+                s.Left = window.Left;
+                s.Top = window.Top;
+                if (rememberSize) { s.Width = window.ActualWidth; s.Height = window.ActualHeight; }
+            }
+            Storage.SaveAppSettings(AppSettings.Current);
+        }
+
+        private static void CenterOnWorkArea(Window window)
+        {
+            var wa = SystemParameters.WorkArea;
+            window.Left = wa.Left + (wa.Width - window.Width) / 2;
+            window.Top = wa.Top + (wa.Height - window.Height) / 2;
+        }
+
+        // ponytail: coarse visibility clamp against the virtual screen — enough to rescue an
+        // off-screen window after a monitor change, not a full per-monitor placement solver.
+        private static void ClampToScreen(Window window)
+        {
+            double vx = SystemParameters.VirtualScreenLeft, vy = SystemParameters.VirtualScreenTop;
+            double vw = SystemParameters.VirtualScreenWidth, vh = SystemParameters.VirtualScreenHeight;
+            double width = double.IsNaN(window.Width) ? window.ActualWidth : window.Width;
+            double height = double.IsNaN(window.Height) ? window.ActualHeight : window.Height;
+            const double margin = 80; // keep at least this much on-screen
+
+            if (window.Left + width < vx + margin) window.Left = vx;
+            else if (window.Left > vx + vw - margin) window.Left = vx + vw - width;
+
+            if (window.Top < vy) window.Top = vy;
+            else if (window.Top > vy + vh - margin) window.Top = vy + vh - height;
+        }
+
+        // ---- Internals ----
+
+        private static WindowLayoutState Layout(string key) =>
+            AppSettings.Current.UILayouts.TryGetValue(key, out var v) ? v : null;
+
+        private static WindowLayoutState LayoutOrNew(string key)
+        {
+            if (!AppSettings.Current.UILayouts.TryGetValue(key, out var v))
+                AppSettings.Current.UILayouts[key] = v = new WindowLayoutState();
+            return v;
+        }
+    }
+}

--- a/PalCalc.UI/View/AppToolbar.xaml
+++ b/PalCalc.UI/View/AppToolbar.xaml
@@ -32,6 +32,8 @@
             <MenuItem Command="{Binding ExportCrashLogCommand}" Header="{itl:LocalizedText LC_EXPORT_CRASH_LOG}" />
             <MenuItem Command="{Binding ForceCheckForUpdatesCommand}" Header="{itl:LocalizedText LC_NAV_FORCE_CHECK_UPDATES}" />
             <MenuItem Command="{Binding OpenAboutWindowCommand}" Header="{itl:LocalizedText LC_ABOUT_APP}" />
+            <Separator />
+            <MenuItem Command="{Binding ResetLayoutCommand}" Header="{itl:LocalizedText LC_RESET_LAYOUT}" />
         </MenuItem>
     </Menu>
 </UserControl>

--- a/PalCalc.UI/View/Inspector/SaveDetailsView.xaml
+++ b/PalCalc.UI/View/Inspector/SaveDetailsView.xaml
@@ -27,11 +27,11 @@
             </CollectionViewSource>
         </Grid.Resources>
         <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="149*" MinWidth="100" MaxWidth="400" />
+            <ColumnDefinition x:Name="LeftColumn" Width="149*" MinWidth="100" MaxWidth="400" />
             <ColumnDefinition Width="Auto" />
-            <ColumnDefinition Width="651*" MinWidth="100" />
+            <ColumnDefinition x:Name="CenterColumn" Width="651*" MinWidth="100" />
             <ColumnDefinition Width="Auto" />
-            <ColumnDefinition Width="300*" MinWidth="100" MaxWidth="600" />
+            <ColumnDefinition x:Name="RightColumn" Width="300*" MinWidth="100" MaxWidth="600" />
         </Grid.ColumnDefinitions>
         <ListBox Grid.Column="0" ItemsSource="{Binding Source={StaticResource GroupedContainers}}" SelectedItem="{Binding SelectedContainer}" IsSynchronizedWithCurrentItem="True" adonisExtensions:ScrollViewerExtension.VerticalScrollBarExpansionMode="AlwaysExpand" HorizontalContentAlignment="Stretch">
             <ListBox.ItemContainerStyle>

--- a/PalCalc.UI/View/Inspector/SaveDetailsView.xaml.cs
+++ b/PalCalc.UI/View/Inspector/SaveDetailsView.xaml.cs
@@ -23,6 +23,8 @@ namespace PalCalc.UI.View.Inspector
         public SaveDetailsView()
         {
             InitializeComponent();
+            PalCalc.UI.Model.WindowStatePersistence.AttachColumns(this, "saveDetails",
+                () => new[] { LeftColumn, CenterColumn, RightColumn });
         }
     }
 }

--- a/PalCalc.UI/View/Inspector/SaveInspectorWindow.xaml.cs
+++ b/PalCalc.UI/View/Inspector/SaveInspectorWindow.xaml.cs
@@ -24,6 +24,7 @@ namespace PalCalc.UI.View.Inspector
         public SaveInspectorWindow()
         {
             InitializeComponent();
+            PalCalc.UI.Model.WindowStatePersistence.AttachWindow(this, "saveInspector");
         }
 
         protected override void OnClosing(CancelEventArgs e)

--- a/PalCalc.UI/View/Inspector/SearchView.xaml
+++ b/PalCalc.UI/View/Inspector/SearchView.xaml
@@ -29,9 +29,9 @@
     </UserControl.Resources>
     <Grid>
         <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="Auto" MinWidth="100"/>
+            <ColumnDefinition x:Name="TreeColumn" Width="Auto" MinWidth="100"/>
             <ColumnDefinition Width="Auto" />
-            <ColumnDefinition Width="20*" MinWidth="100"/>
+            <ColumnDefinition x:Name="ResultsColumn" Width="20*" MinWidth="100"/>
         </Grid.ColumnDefinitions>
 
         <GroupBox Header="{itl:LocalizedText LC_SAVESEARCH_GRP_PAL_CONTAINERS}" Grid.Column="0">

--- a/PalCalc.UI/View/Inspector/SearchView.xaml.cs
+++ b/PalCalc.UI/View/Inspector/SearchView.xaml.cs
@@ -26,6 +26,8 @@ namespace PalCalc.UI.View.Inspector
         public SearchView()
         {
             InitializeComponent();
+            PalCalc.UI.Model.WindowStatePersistence.AttachColumns(this, "search",
+                () => new[] { TreeColumn, ResultsColumn });
         }
 
         public SearchViewModel ViewModel => DataContext as SearchViewModel;

--- a/PalCalc.UI/View/SolverPage.xaml
+++ b/PalCalc.UI/View/SolverPage.xaml
@@ -29,11 +29,11 @@
         <DockPanel>
             <Grid>
                 <Grid.ColumnDefinitions>
-                    <ColumnDefinition MinWidth="220" Width="300"/>
+                    <ColumnDefinition x:Name="LeftColumn" MinWidth="220" Width="300"/>
                     <ColumnDefinition Width="Auto"/>
-                    <ColumnDefinition Width="232*" MinWidth="250" />
+                    <ColumnDefinition x:Name="CenterColumn" Width="232*" MinWidth="250" />
                     <ColumnDefinition Width="Auto"/>
-                    <ColumnDefinition Width="80*" MinWidth="280"/>
+                    <ColumnDefinition x:Name="RightColumn" Width="80*" MinWidth="280"/>
                 </Grid.ColumnDefinitions>
                 <!-- Left-hand Pane -->
                 <DockPanel Grid.Column="0">
@@ -161,9 +161,9 @@
 
                     <Grid Grid.Row="1">
                         <Grid.RowDefinitions>
-                            <RowDefinition Height="30*" />
+                            <RowDefinition x:Name="SourcePalsRow" Height="30*" />
                             <RowDefinition Height="Auto" />
-                            <RowDefinition Height="60*" MinHeight="150" />
+                            <RowDefinition x:Name="ResultsRow" Height="60*" MinHeight="150" />
                         </Grid.RowDefinitions>
 
                         <!-- "Source Pals" section -->

--- a/PalCalc.UI/View/SolverPage.xaml.cs
+++ b/PalCalc.UI/View/SolverPage.xaml.cs
@@ -30,6 +30,7 @@ namespace PalCalc.UI
         internal SolverPage()
         {
             InitializeComponent();
+            WindowStatePersistence.AttachGrid(this, "solver", () => Columns, () => Rows);
 
             DataContext = new SolverPageViewModel(Dispatcher, null, null, null);
         }
@@ -37,10 +38,24 @@ namespace PalCalc.UI
         internal SolverPage(SolverPageViewModel vm)
         {
             InitializeComponent();
+            WindowStatePersistence.AttachGrid(this, "solver", () => Columns, () => Rows);
             DataContext = vm;
         }
 
         private SolverPageViewModel ViewModel => DataContext as SolverPageViewModel;
+
+        private IReadOnlyList<ColumnDefinition> Columns => new[] { LeftColumn, CenterColumn, RightColumn };
+        private IReadOnlyList<RowDefinition> Rows => new[] { SourcePalsRow, ResultsRow };
+
+        // Default sizes from SolverPage.xaml — used by the Reset Window Layout action.
+        public void ResetLayout()
+        {
+            LeftColumn.Width = new GridLength(300);
+            CenterColumn.Width = new GridLength(232, GridUnitType.Star);
+            RightColumn.Width = new GridLength(80, GridUnitType.Star);
+            SourcePalsRow.Height = new GridLength(30, GridUnitType.Star);
+            ResultsRow.Height = new GridLength(60, GridUnitType.Star);
+        }
 
         private void Hyperlink_RequestNavigate(object sender, RequestNavigateEventArgs e)
         {

--- a/PalCalc.UI/ViewModel/AppToolbarViewModel.cs
+++ b/PalCalc.UI/ViewModel/AppToolbarViewModel.cs
@@ -21,6 +21,7 @@ using System.IO.Compression;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Windows;
 using System.Windows.Threading;
 using AdonisMessageBox = AdonisUI.Controls.MessageBox;
 
@@ -60,6 +61,21 @@ namespace PalCalc.UI.ViewModel
                     AdonisMessageBox.Show(LocalizationCodes.LC_CRASHLOG_FAILED.Bind().Value, caption: "");
                 }
             }
+        }
+
+        [RelayCommand]
+        private void ResetLayout()
+        {
+            AppSettings.Current.UILayouts.Clear();
+            Storage.SaveAppSettings(AppSettings.Current);
+
+            // Re-apply defaults live to the open main window + solver page.
+            if (App.Current.MainWindow is Window main)
+                WindowStatePersistence.ResetToDefault(main, 1280, 720);
+
+            if (App.Current.MainWindow?.DataContext is AppWindowViewModel appVm &&
+                appVm.Content is SolverPage solver)
+                solver.ResetLayout();
         }
 
         [RelayCommand]

--- a/PalCalc.UI/ViewModel/AppWindowViewModel.cs
+++ b/PalCalc.UI/ViewModel/AppWindowViewModel.cs
@@ -177,6 +177,9 @@ namespace PalCalc.UI.ViewModel
             page.DataContext = vm;
 
             Content = page;
+
+            // Save selection uses the default window size; remembered size applies on the solver page.
+            WindowStatePersistence.ApplyDefaultSize(App.Current.MainWindow);
         }
 
         private void NavigateSolverPage(SaveGameViewModel selectedSave)
@@ -192,6 +195,9 @@ namespace PalCalc.UI.ViewModel
             var saveOperations = new CommonSaveOperationsViewModel(BeginNavigateSaveSelectionPageCommand, selectedSave.Parent, selectedSave);
             var vm = new SolverPageViewModel(Dispatcher.CurrentDispatcher, saveOperations, selectedSave, LoadPalTargets(selectedSave));
             Content = new SolverPage(vm);
+
+            // Apply the size the user last used on the solver page.
+            WindowStatePersistence.ApplySolverSize(App.Current.MainWindow);
         }
 
         private PalTargetListViewModel LoadPalTargets(SaveGameViewModel sg)

--- a/PalCalc.sln
+++ b/PalCalc.sln
@@ -43,6 +43,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AdonisUI.ClassicTheme", "ad
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PalCalc.Model.Tests", "PalCalc.Model.Tests\PalCalc.Model.Tests.csproj", "{712B99CA-8B44-4E7B-A2F6-4FD198532268}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PalCalc.UI.Tests", "PalCalc.UI.Tests\PalCalc.UI.Tests.csproj", "{17AAD9E3-E45F-4D68-AF15-D0950E090533}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
@@ -134,6 +136,12 @@ Global
 		{712B99CA-8B44-4E7B-A2F6-4FD198532268}.Release_NoBundle|x64.Build.0 = Release|Any CPU
 		{712B99CA-8B44-4E7B-A2F6-4FD198532268}.Release|x64.ActiveCfg = Release|Any CPU
 		{712B99CA-8B44-4E7B-A2F6-4FD198532268}.Release|x64.Build.0 = Release|Any CPU
+		{17AAD9E3-E45F-4D68-AF15-D0950E090533}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{17AAD9E3-E45F-4D68-AF15-D0950E090533}.Debug|x64.Build.0 = Debug|Any CPU
+		{17AAD9E3-E45F-4D68-AF15-D0950E090533}.Release_NoBundle|x64.ActiveCfg = Release|Any CPU
+		{17AAD9E3-E45F-4D68-AF15-D0950E090533}.Release_NoBundle|x64.Build.0 = Release|Any CPU
+		{17AAD9E3-E45F-4D68-AF15-D0950E090533}.Release|x64.ActiveCfg = Release|Any CPU
+		{17AAD9E3-E45F-4D68-AF15-D0950E090533}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Fixes #212. App now remember UI layout between sessions.

What persist:
- Main window position, maximized, and snap-to-side bounds.
- Solver pane widths, plus the source-pals / results row split.
- Save inspector window placement, and its search/details pane widths.
- New Help > Reset Window Layout to restore defaults.

Save selection and loading screens open at default size (only position remembered). Full window size remembered only after a save is selected (solver page), re-applied on select. Reason: save selection page looked wrong scaled up to a large remembered window.

Storage: AppSettings (data/settings.json) via shared WindowStatePersistence helper. Added PalCalc.UI.Tests for column/row and settings round-trip.

Note: not sure yet about the save selection window behavior, or whether current implementation is the right approach. Open to feedback.