### PR TITLE
Use the container's authoritative slot index for Pal locations

### DIFF
--- a/PalCalc.SaveReader/SaveFile/LevelSaveFile.cs
+++ b/PalCalc.SaveReader/SaveFile/LevelSaveFile.cs
@@ -269,7 +269,8 @@ namespace PalCalc.SaveReader.SaveFile
                     }
 
                     var container = parsed.ContainerContents.Single(c => c.Id == gvasInstance.ContainerId.ToString());
-                    if (!container.Slots.Any(s => s.InstanceId == gvasInstance.InstanceId))
+                    var containerSlot = container.Slots.FirstOrDefault(s => s.InstanceId == gvasInstance.InstanceId);
+                    if (containerSlot == null)
                     {
                         logger.Debug("pal instance data '{palId}' references container '{containerId}' but the container has no record of this pal, skipping", gvasInstance.InstanceId, container.Id);
                         continue;
@@ -278,6 +279,8 @@ namespace PalCalc.SaveReader.SaveFile
                     var pal = gvasInstance.ToPalInstance(db, containerTypeById[gvasInstance.ContainerId.ToString()]);
                     if (pal != null)
                     {
+                        pal.Location.Index = containerSlot.SlotIndex;
+
                         if (pal.OwnerPlayerId == null)
                         {
                             // #198 - `OwnerPlayerId` may be null and `OldOwnerPlayerIds` may be empty


### PR DESCRIPTION

**TL;DR:** A Pal's displayed slot ("Palbox Tab 20 at (4,1)") is read from the
Pal instance's own `SlotID`, not from the container's slot record. Those two can
disagree, and when they do PalCalc points you at the wrong slot. Fix reads the
slot index from the container, which is the source of truth the game itself uses.

## The bug

A Pal's grid position has two sources in the save:

1. the Pal instance's own `SlotID.n` (what `LevelSaveFile` currently uses), and
2. the container's slot record `.Slots.n` (the layout the game reads).

Today the location is taken from source 1. When the two drift, the location
shown in PalCalc is wrong, so you go to the slot it names and the Pal is not
there.

## Why it usually goes unnoticed

In a normal save the instance `SlotID` matches the container layout, so the
displayed slot is correct and nobody notices. It only drifts in edge cases:

- saves touched by the 0.3.3 container change (empty slots no longer stored,
  slots carry an explicit index),
- Pals that have been moved/reorganized,
- anything that rewrites the container layout without rewriting each instance's
  `SlotID`.

It is also silent: to catch it you have to compare PalCalc's slot against the
real in-game grid, which almost no one does.

## Mods make it reliably reproducible

Palbox sorting mods are the clearest trigger. Example, the `PalboxSearchbar`
UE4SS mod, when it sorts, reorders the container array and rewrites each
**container** slot index:

```lua
for i = 1, #sortedFull do
    array[i] = sortedFull[i]
    pcall(function() array[i].SlotIndex = i - 1 end)
end
```

It updates the container slot index but leaves each Pal's own `SlotID`
untouched. After a sort the container says "Pal X is in slot 5" while the
instance still says "slot 40". PalCalc trusts the instance value and shows the
stale slot. The Pals are still in the container (same container, just reordered),
so they are not dropped, only mislocated.

On a save sorted this way I also hit a crash in the Pal inspector, not just a
wrong label. The stale, colliding indices appear to be enough to break the
inspector's slot handling. Reading the authoritative container index fixes the
crash along with the wrong locations.

## The fix

Look the Pal up in the container's slot list and stamp the location with that
slot's index:

```csharp
var containerSlot = container.Slots.FirstOrDefault(s => s.InstanceId == gvasInstance.InstanceId);
if (containerSlot == null) { /* existing skip path, unchanged */ }
...
pal.Location.Index = containerSlot.SlotIndex;
```

## Scope / risk

One file, ~4 lines. The lookup replaces an existing `Any(...)` membership check
with a `FirstOrDefault(...)` on the same predicate, so the skip behavior is
unchanged; it only adds the authoritative index assignment. No effect on solver
results, only on the displayed location.
