### PR TITLE
Label Dimensional Pal Storage locations by storage holder

### DIFF
--- a/PalCalc.UI/ViewModel/Mapped/PalRefLocationViewModel.cs
+++ b/PalCalc.UI/ViewModel/Mapped/PalRefLocationViewModel.cs
@@ -71,7 +71,21 @@ namespace PalCalc.UI.ViewModel.Mapped
 
                 if (ownedLoc.Location.Type != LocationType.Custom && ownedLoc.Location.Type != LocationType.GlobalPalStorage)
                 {
-                    var rawOwnerName = source?.PlayersById?.GetValueOrDefault(ownedLoc.OwnerId)?.Name;
+                    // In Dimensional Pal Storage ("DPS") a pal's OwnerPlayerId may differ from whose
+                    // storage it physically sits in, because players can hold each other's pals there.
+                    // The location label should name the holder - the storage you actually open -
+                    // matching how the source tree already groups DPS pals by container. For other
+                    // location types owner == holder.
+                    var ownerLookupId = ownedLoc.OwnerId;
+                    if (ownedLoc.Location.Type == LocationType.DimensionalPalStorage)
+                    {
+                        var holderId = source?.PalContainers
+                            ?.OfType<DimensionalPalStorageContainer>()
+                            .FirstOrDefault(c => c.Id == ownedLoc.Location.ContainerId)?.PlayerId;
+                        if (holderId != null) ownerLookupId = holderId;
+                    }
+
+                    var rawOwnerName = source?.PlayersById?.GetValueOrDefault(ownerLookupId)?.Name;
 
                     ILocalizedText ownerName = rawOwnerName != null
                         ? new HardCodedText(rawOwnerName)


### PR DESCRIPTION
**TL;DR:** In a co-op save, a Pal in Dimensional Pal Storage ("DPS") can be
owned by one player but stored in another's DPS. The solver's location label
named the Pal's owner, not whose storage it actually sits in, so it could point
you at the wrong player's storage.

## The bug

Everything about DPS in the solver is keyed by the container holder. The source
tree groups a DPS Pal under whoever's storage it physically sits in
(`PalSourceTreeSelection`, DPS matched by `ContainerId`). But the location label
was resolved from the Pal's `OwnerPlayerId` (`PalRefLocationViewModel`).

Those two are not the same in co-op. Players routinely hold each other's Pals in
DPS, so a Pal owned by player A can live in player B's DPS. The tree then files
it under B while the label reads "A", and the solver tells you to open A's
storage even though the Pal is in B's.

## Repro (real co-op save)

On a two-player save (Player A, Player B):

- Player A's DPS: 641 Pals = 460 owned by A + 181 owned by B
- Player B's DPS: 378 Pals = 262 owned by B + 116 owned by A

297 of 1019 DPS Pals had `OwnerPlayerId` different from their storage holder, so
297 location labels named the wrong player.

## The fix

For `DimensionalPalStorage` locations, resolve the owner label from the
container holder (`ContainerId` -> `DimensionalPalStorageContainer.PlayerId`)
instead of `OwnerPlayerId`. This matches the tree grouping and answers the
question the label is for: "whose storage do I open to get this Pal".

`OwnerPlayerId` is left untouched, so the inspector and any owner-based logic
still see the Pal's true owner. Other location types are unaffected (owner and
holder are always the same there).

## Scope / risk

One file, display only. Verified against the co-op save above: all 297
mislabeled Pals now resolve to the correct holder, every DPS container resolves,
and `OwnerPlayerId` is unchanged.
