### PR TITLE
fix: known IV of 0 treated as random IV

### DIFF
--- a/PalCalc.Solver.Tests/Processing/CandidateExpanderTests.cs
+++ b/PalCalc.Solver.Tests/Processing/CandidateExpanderTests.cs
@@ -73,6 +73,23 @@ public class CandidateExpanderTests
         );
     }
 
+    [TestMethod]
+    public void ExpandBatch_TreatsKnownZeroIVAsRealValue()
+    {
+        var expansion = Expand(
+            SolverTestScenario.Owned("Katress", PalGender.MALE, ivHp: 0),
+            SolverTestScenario.Owned("Wixen", PalGender.FEMALE, ivHp: 98),
+            new PalSpecifier
+            {
+                Pal = "Wixen Noct".ToPal(SolverTestScenario.DB),
+            }
+        );
+
+        var childHP = expansion.Candidates.Single().IVs.HP;
+        Assert.AreEqual(0, childHP.Min);
+        Assert.AreEqual(98, childHP.Max);
+    }
+
     private static ExpansionResult Expand(
         PalInstance first,
         PalInstance second,

--- a/PalCalc.Solver/PalReference/Properties/IV_Value.cs
+++ b/PalCalc.Solver/PalReference/Properties/IV_Value.cs
@@ -10,7 +10,9 @@ namespace PalCalc.Solver.PalReference.Properties
     {
         public bool Satisfies(int minValue) => Min >= minValue;
 
-        public static readonly IV_Value Random = new(false, 0, 0);
+        // Min/Max of -1 keeps this distinct from a known IV of 0, which is a real
+        // value that must still be merged as a possible inherited result.
+        public static readonly IV_Value Random = new(false, -1, -1);
 
         public static IV_Value Merge(IV_Value a, IV_Value b)
         {

--- a/PalCalc.Solver/Processing/Search/CandidateSelectionPolicy.cs
+++ b/PalCalc.Solver/Processing/Search/CandidateSelectionPolicy.cs
@@ -1,4 +1,5 @@
 using PalCalc.Solver.PalReference;
+using PalCalc.Solver.PalReference.Properties;
 using PalCalc.Solver.ResultPruning;
 
 namespace PalCalc.Solver.Processing.Search;
@@ -184,15 +185,19 @@ internal sealed class DefaultCandidateSelectionPolicy : ICandidateSelectionPolic
     public BreedingEffortGroupKey BreedingEffortGroupOf(IPalReference candidate) =>
         new(candidate.BreedingEffort.Ticks);
 
+    // random IVs have no known value and score as zero
+    private static int ScoreOf(IV_Value iv, Func<IV_Value, int> select) =>
+        iv == IV_Value.Random ? 0 : select(iv);
+
     private static int TotalMaxIV(IPalReference candidate) =>
-        candidate.IVs.HP.Max +
-        candidate.IVs.Attack.Max +
-        candidate.IVs.Defense.Max;
+        ScoreOf(candidate.IVs.HP, iv => iv.Max) +
+        ScoreOf(candidate.IVs.Attack, iv => iv.Max) +
+        ScoreOf(candidate.IVs.Defense, iv => iv.Max);
 
     private static int TotalMinIV(IPalReference candidate) =>
-        candidate.IVs.HP.Min +
-        candidate.IVs.Attack.Min +
-        candidate.IVs.Defense.Min;
+        ScoreOf(candidate.IVs.HP, iv => iv.Min) +
+        ScoreOf(candidate.IVs.Attack, iv => iv.Min) +
+        ScoreOf(candidate.IVs.Defense, iv => iv.Min);
 
     private sealed class BreedingEffortComparer : IComparer<IPalReference>
     {


### PR DESCRIPTION
## Problem

`IV_Value.Random` is `new(false, 0, 0)`. A pal with a real IV of 0 and no IV target set produces exactly that value (`InitialPalBuilder.MakeIV`), so known-zero and random are indistinguishable.

`CandidateExpander.MergeIVs` drops the "random" parent. Breed HP 0 parent with HP 98 parent, and the child is reported as guaranteed **98**. Real answer is **0-98** - child inherits from one parent or the other.

Same collision in the UI: owned pal with real IV 0 renders as `(Random)`.

## Cause

Regression from f6b203bf ("Optimization - convert IV_IValue into a flat struct"). Before it, `IV_Random` was its own type and merge matched on type, so `IV_Range(false, 0, 0)` merged normally. Flattening into a record struct made it value equality. Solver domain refactor (#222) only moved the code, logic unchanged.

## Fix

- `IV_Value.Random` moves to `new(false, -1, -1)`. No longer collides with a real value.
- `CandidateSelectionPolicy` frontier IV totals score random as 0, so ranking behavior is unchanged by the new sentinel.

## Test

New `CandidateExpanderTests.ExpandBatch_TreatsKnownZeroIVAsRealValue`. Fails before fix with `Expected:<0>. Actual:<98>`, passes after. Full solver suite green (151/151). 

<img width="2613" height="1143" alt="image" src="https://github.com/user-attachments/assets/1bb9e5b4-8194-4142-9ca1-9c2420cf8c1f" />

